### PR TITLE
Added command to create the "certdir" directory

### DIFF
--- a/setup-cert.sh
+++ b/setup-cert.sh
@@ -4,6 +4,9 @@
 certdir="tls"
 host="localhost"
 
+# certdir directory has to be created
+mkdir tls
+
 # setup a CA key
 if [ ! -f "$certdir/ca-key.pem" ]; then
   openssl genrsa -out "${certdir}/ca-key.pem" 4096


### PR DESCRIPTION
If the directory is not created before, one will get error:
```
$ ./setup-cert.sh
genrsa: Can't open "tls/ca-key.pem" for writing, No such file or directory
Can't open tls/ca-key.pem for reading, No such file or directory
...
```